### PR TITLE
fix: mobile Header collapsing and CoC usage:

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,3 @@
----
-
----
-
 <header>
 	<details id="details">
 		<summary aria-label="Toggle header">≡</summary>
@@ -24,6 +20,18 @@
 		<a href="#faqs">FAQs</a>
 	</div>
 </header>
+
+<script>
+	const details = document.querySelector(
+		"details#details",
+	) as HTMLDetailsElement;
+	details.addEventListener("click", (event) => {
+		console.log((event as any).target.tagName);
+		if ((event.target as Partial<HTMLElement>).tagName === "A") {
+			details.removeAttribute("open");
+		}
+	});
+</script>
 
 <style>
 	header {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,12 +1,9 @@
 ---
 import SquiggleLong from "~/assets/squiggle-long.svg";
 
-import Header from "./Header.astro";
 import SquiggleWave from "./SquiggleWave.astro";
 import ThemeToggle from "./ThemeToggle.astro";
 ---
-
-<Header />
 
 <div class="hero" id="home">
 	<ThemeToggle />

--- a/src/components/HeroForPage.astro
+++ b/src/components/HeroForPage.astro
@@ -25,7 +25,6 @@ import Hero from "~/components/Hero.astro";
 		font-family: var(--fontFamilyBody);
 		text-decoration: none;
 		font-size: var(--fontSizeH3);
-		text-align: left;
 		display: block;
 	}
 
@@ -35,5 +34,11 @@ import Hero from "~/components/Hero.astro";
 
 	.contents-body-text {
 		margin: 2rem auto;
+	}
+
+	@media (min-width: 819px) {
+		.back {
+			text-align: left;
+		}
 	}
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,14 +1,16 @@
 ---
 import AboutUs from "~/components/AboutUs.astro";
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import Calls from "~/components/Calls.astro";
 import FAQs from "~/components/FAQs.astro";
+import Header from "~/components/Header.astro";
+import Information from "~/components/Information.astro";
 import PrimaryHero from "~/components/PrimaryHero.astro";
 import Speakers from "~/components/Speakers.astro";
-import BaseLayout from "~/layouts/BaseLayout.astro";
-import Information from "~/components/Information.astro";
-import Calls from "~/components/Calls.astro";
 ---
 
 <BaseLayout>
+	<Header />
 	<PrimaryHero />
 	<div class="contents">
 		<Information />


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #17
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/SquiggleConf/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/SquiggleConf/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses some basic Astro scripting to close the header.

Also, while I'm in the area, removes the header from the CoC page. Because it doesn't need to be there and does nothing on the page.